### PR TITLE
Run sshd in Containers and enable Geo-rep tests

### DIFF
--- a/glustertester/scripts/Dockerfile
+++ b/glustertester/scripts/Dockerfile
@@ -37,6 +37,27 @@ COPY run-tests.sh /usr/share/glusterfs/
 RUN chmod +x /usr/share/glusterfs/regression.sh
 RUN chmod +x /usr/share/glusterfs/run-tests.sh
 
+# SSH related things
+# Based on https://docs.docker.com/engine/examples/running_ssh_service/
+RUN mkdir /var/run/sshd
+RUN echo 'root:gluster' | chpasswd
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+RUN ssh-keygen -t rsa -N "" -b 4096 -f /etc/ssh/ssh_host_rsa_key
+
+# For Geo-rep, Prepare password less ssh
+RUN mkdir -p /root/.ssh
+RUN rm -rf .ssh/id_rsa*
+RUN ssh-keygen -N "" -f /root/.ssh/id_rsa
+RUN cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+
+EXPOSE 22
+
 ARG version="(unknown)"
 # Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 ARG builddate="(unknown)"
@@ -50,4 +71,4 @@ LABEL vcs-url="https://github.com/gluster/glusterfs"
 LABEL vendor="gluster"
 LABEL version="${version}"
 
-ENTRYPOINT ["tail", "-f", "/dev/null"]
+CMD ["/usr/sbin/sshd", "-D"]

--- a/glustertester/scripts/base.Dockerfile
+++ b/glustertester/scripts/base.Dockerfile
@@ -28,12 +28,6 @@ RUN if [ "x$baseos" = "xfedora" ]; then \
         python3-pyxattr iproute-tc iputils \
         ;fi
 
-# For Geo-rep, Prepare password less ssh
-RUN mkdir -p /root/.ssh
-RUN rm -rf .ssh/id_rsa*
-RUN ssh-keygen -N "" -f /root/.ssh/id_rsa
-RUN cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
-
 ARG version="(unknown)"
 # Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 ARG builddate="(unknown)"
@@ -46,5 +40,3 @@ LABEL vcs-type="git"
 LABEL vcs-url="https://github.com/gluster/glusterfs"
 LABEL vendor="gluster"
 LABEL version="${version}"
-
-ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/glustertester/scripts/run-tests.py
+++ b/glustertester/scripts/run-tests.py
@@ -15,6 +15,7 @@ def run_tests(args):
 
         cmd = ("docker exec glusterfs-tester-%d bash "
                "/usr/share/glusterfs/regression.sh "
+               "-t 300 "
                "-i /root/tests/tests-%d.dat " % (num+1, num+1)
         )
 

--- a/glustertester/scripts/split-tests.py
+++ b/glustertester/scripts/split-tests.py
@@ -8,9 +8,6 @@ from argparse import ArgumentParser
 
 def get_list_of_tests(rootdir, testdir, tests, output_prefix=None):
     for testfile in os.listdir(testdir):
-        if testfile == "00-geo-rep":
-            continue
-
         full_path = os.path.join(testdir, testfile)
         if testfile.endswith(".t"):
             outpath = full_path.replace(rootdir + "/", "")


### PR DESCRIPTION
Started running sshd inside container as mentioned in the
following documentation

https://docs.docker.com/engine/examples/running_ssh_service/

Geo-rep tests are now running fine, reenabled those tests.

Updates: #9
Signed-off-by: Aravinda VK <avishwan@redhat.com>