### PR TITLE
Container hostname is changed to avoid a disperse test failure

### DIFF
--- a/glustertester/main.py
+++ b/glustertester/main.py
@@ -119,11 +119,15 @@ def subcmd_run(args):
         bddir = os.path.join(args.backenddir, "bd-%d" % num)
         imgname = "gluster/glusterfs-tester:latest"
         name = "glusterfs-tester-%d" % num
+        hostname = "gnode%d" % num
         run_else_exit(
             "docker run -d"
             " --cap-add sys_admin"
             " --privileged=true"
+            " --hostname " + hostname +
             " --device /dev/fuse"
+            " --sysctl net.ipv6.conf.all.disable_ipv6=1"
+            " --sysctl net.ipv6.conf.default.disable_ipv6=1"
             " --name " + name +
             " --mount type=bind,source=" + logdir + ",target=/var/log"
             " --mount type=bind,source=" + bddir + ",target=/d"

--- a/glustertester/scripts/testutils.py
+++ b/glustertester/scripts/testutils.py
@@ -176,7 +176,7 @@ def clean_logdir(logdir):
         return
 
     to_delete = []
-    for root, _, files in os.walk(tardir):
+    for root, _, files in os.walk(logdir):
         for filename in files:
             if not filename.endswith(".tar"):
                 to_delete.append(os.path.join(root, filename))


### PR DESCRIPTION
Disperse volume can be created without specifying disperse count, that is
when disperse is specified but no count is given. Disperse count will be
derived from the bricks count.

For example, the following command fails in container because hostname starts
with numeric and gluster CLI tries to parse it as disperse count.

```
gluster --mode=script volume create patchy \
    disperse 619244e42b58:/d/backends/b1 \
    619244e42b58:/d/backends/b2 619244e42b58:/d/backends/b3
```

Also disabled the ipv6 using `--sysctl` command while running container.

Signed-off-by: Aravinda VK <avishwan@redhat.com>